### PR TITLE
Fix flash speed for esp32-c3-devkitm-1

### DIFF
--- a/boards/esp32-c3-devkitm-1.json
+++ b/boards/esp32-c3-devkitm-1.json
@@ -5,7 +5,7 @@
     },
     "core": "esp32",
     "f_cpu": "160000000L",
-    "f_flash": "80000000L",
+    "f_flash": "40000000L",
     "flash_mode": "qio",
     "mcu": "esp32c3",
     "variant": "esp32c3"


### PR DESCRIPTION
I got this device for ESPresense: https://www.aliexpress.com/item/1005006399553064.html
When flashing the device with the stock ESPresence image for ESP32-C3, it gets stuck in a bootloop, adding this to `platformio.ini` and manually building fixed the issue for me (I saw these setting being recommended at multiple places, only f_flash is different than the current configuration):

```
board_build.f_flash = 40000000L
board_build.flash_mode = dio
board_build.flash_size = 4MB
```